### PR TITLE
Fix stripe checkout user lookup

### DIFF
--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
-import { createClient } from '@/lib/supabase-client';
+import { createClient } from '@/lib/auth';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: '2024-12-18.acacia',
@@ -14,7 +14,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'User ID is required' }, { status: 400 });
     }
 
-    const supabase = createClient();
+    const supabase = await createClient();
     const { data: user } = await supabase
       .from('profiles')
       .select('email, full_name')

--- a/app/auth/simple-signup/page.tsx
+++ b/app/auth/simple-signup/page.tsx
@@ -30,13 +30,26 @@ export default function SimpleSignupPage() {
         email,
         password,
         options: {
-          data: { name },
+          data: { full_name: name },
         },
       })
 
       if (error) {
         setError(error.message)
       } else {
+        if (data.user) {
+          const { error: profileError } = await supabase.from("profiles").upsert({
+            id: data.user.id,
+            email: data.user.email!,
+            full_name: name,
+            role: "user",
+            updated_at: new Date().toISOString(),
+          })
+
+          if (profileError) {
+            console.error("Profile creation error:", profileError)
+          }
+        }
         setMessage("Account created! Please check your email to verify your account.")
       }
     } catch (err: any) {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -50,7 +50,11 @@ export default function LoginPage() {
         const { error: profileError } = await supabase.from("profiles").upsert({
           id: data.user.id,
           email: data.user.email,
-          name: data.user.user_metadata?.name || data.user.email?.split("@")[0] || "User",
+          full_name:
+            data.user.user_metadata?.full_name ||
+            data.user.user_metadata?.name ||
+            data.user.email?.split("@")[0] ||
+            "User",
           role: "user",
           updated_at: new Date().toISOString(),
         })

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -64,6 +64,18 @@ export default function SignUpPage() {
 
       if (data.user) {
         console.log("Sign up successful:", data.user.email)
+        // Create profile record for new user
+        const { error: profileError } = await supabase.from("profiles").upsert({
+          id: data.user.id,
+          email: data.user.email,
+          full_name: name.trim(),
+          role: "user",
+          updated_at: new Date().toISOString(),
+        })
+
+        if (profileError) {
+          console.error("Profile creation error:", profileError)
+        }
         setSuccess(true)
 
         // If user is immediately confirmed (no email verification required)

--- a/lib/actions/auth.ts
+++ b/lib/actions/auth.ts
@@ -18,7 +18,7 @@ export async function signUp(formData: FormData) {
     password,
     options: {
       data: {
-        name,
+        full_name: name,
       },
       emailRedirectTo: `${process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"}/auth/callback`,
     },
@@ -36,7 +36,7 @@ export async function signUp(formData: FormData) {
     const { error: profileError } = await supabase.from("profiles").upsert({
       id: authData.user.id,
       email,
-      name,
+      full_name: name,
       role: "user",
     })
 


### PR DESCRIPTION
## Summary
- create profiles upon user signup
- store full name instead of name in profile records
- ensure stripe checkout route uses authenticated Supabase client

## Testing
- `pnpm install`
- `pnpm lint` *(fails: ESLint requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68793bc0dc50832c93bd282c5daf0fe2