### PR TITLE
Fix Supabase usage for Stripe checkout

### DIFF
--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
 
 const supabaseUrl = process.env.SUPABASE_URL;
-const serviceKey = process.env.SUPABASE_SERVICE_KEY;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 let stripe: Stripe | null = null;
 const stripeSecret = process.env.STRIPE_SECRET_KEY;
@@ -12,8 +12,8 @@ if (stripeSecret) {
   });
 }
 
-// Import your Supabase client factory if needed
-import { createClient } from '@/lib/supabase-client';
+// Use server-side Supabase client with service role key
+import { createClient } from '@supabase/supabase-js';
 
 export async function POST(req: NextRequest) {
   try {

--- a/components/auth-navbar.tsx
+++ b/components/auth-navbar.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import type { User } from "@supabase/supabase-js"
-import { createClient } from "@supabase/supabase-js"
+import { createClient } from "@/lib/auth-client"
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { VisuallyHidden } from "@/components/ui/visually-hidden"
@@ -25,20 +25,7 @@ interface Profile {
   role: "user" | "admin" | "master_admin"
 }
 
-// Use the same client configuration as db.ts to avoid multiple instances
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-
-let supabaseClient: any = null
-if (typeof window !== 'undefined' && !supabaseClient) {
-  supabaseClient = createClient(supabaseUrl, supabaseAnonKey, {
-    auth: {
-      autoRefreshToken: true,
-      persistSession: true,
-      detectSessionInUrl: true,
-    },
-  })
-}
+const supabaseClient = createClient()
 
 export default function AuthNavbar() {
   const [user, setUser] = useState<User | null>(null)

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -38,5 +38,47 @@ export async function createClient() {
 }
 
 export async function getUser() {
-  // ...your existing getUser implementation...
+  const supabase = await createClient()
+  if (!supabase.auth) {
+    return null
+  }
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+
+  if (error || !user) {
+    return null
+  }
+
+  // Try to get profile data
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("*")
+    .eq("id", user.id)
+    .single()
+
+  return {
+    id: user.id,
+    email: user.email!,
+    name: profile?.name || user.user_metadata?.name || "User",
+    role: profile?.role || "user",
+  }
+}
+
+export async function requireAuth() {
+  const user = await getUser()
+  if (!user) {
+    throw new Error("Authentication required")
+  }
+  return user
+}
+
+export async function requireAdmin() {
+  const user = await requireAuth()
+  if (user.role !== "admin" && user.role !== "master_admin") {
+    throw new Error("Admin access required")
+  }
+  return user
 }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,13 +1,13 @@
-import { createClient } from "@supabase/supabase-js"
+import { createClient as createAdminClient } from "@supabase/supabase-js"
+import { createClient } from "@/lib/supabase-client"
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
 // Create a Supabase client with service role key for admin operations (server-side only)
 const supabaseAdmin =
   typeof window === 'undefined' && supabaseUrl && supabaseServiceKey
-    ? createClient(supabaseUrl, supabaseServiceKey, {
+    ? createAdminClient(supabaseUrl, supabaseServiceKey, {
         auth: {
           autoRefreshToken: false,
           persistSession: false,
@@ -16,23 +16,7 @@ const supabaseAdmin =
     : null
 
 // Create a single Supabase client for user operations (avoid multiple instances)
-let supabase: any = null
-if (supabaseUrl && supabaseAnonKey) {
-  if (typeof window !== 'undefined') {
-    if (!supabase) {
-      supabase = createClient(supabaseUrl, supabaseAnonKey, {
-        auth: {
-          autoRefreshToken: true,
-          persistSession: true,
-          detectSessionInUrl: true,
-        },
-      })
-    }
-  } else {
-    // Server-side: create a fresh instance each time
-    supabase = createClient(supabaseUrl, supabaseAnonKey)
-  }
-}
+const supabase = createClient()
 
 export interface User {
   id: string

--- a/lib/supabase-client.ts
+++ b/lib/supabase-client.ts
@@ -6,10 +6,16 @@ const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 if (!supabaseUrl || !supabaseAnonKey) {
   console.error("Missing Supabase environment variables")
   console.error("NEXT_PUBLIC_SUPABASE_URL:", supabaseUrl ? "Present" : "Missing")
-  console.error("NEXT_PUBLIC_SUPABASE_ANON_KEY:", supabaseAnonKey ? "Present" : "Missing")
+  console.error(
+    "NEXT_PUBLIC_SUPABASE_ANON_KEY:",
+    supabaseAnonKey ? "Present" : "Missing",
+  )
 }
 
-let supabase: ReturnType<typeof createBrowserClient> | null = null
+declare global {
+  // eslint-disable-next-line no-var
+  var __supabaseClient: ReturnType<typeof createBrowserClient> | undefined
+}
 
 export function createClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -18,10 +24,18 @@ export function createClient() {
     console.error("Supabase environment variables not set")
     return {} as any
   }
-  if (!supabase) {
-    supabase = createBrowserClient(url, key)
+
+  if (typeof window !== "undefined") {
+    if (!globalThis.__supabaseClient) {
+      globalThis.__supabaseClient = createBrowserClient(url, key)
+    }
+    return globalThis.__supabaseClient
   }
-  return supabase
+
+  if (!globalThis.__supabaseClient) {
+    globalThis.__supabaseClient = createBrowserClient(url, key)
+  }
+  return globalThis.__supabaseClient
 }
 
 export function isSupabaseConfigured(): boolean {


### PR DESCRIPTION
## Summary
- use correct SUPABASE_SERVICE_ROLE_KEY for Stripe checkout API
- create checkout Supabase client using the server SDK
- share browser Supabase instance through `lib/supabase-client` in DB helper

## Testing
- `pnpm install`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879ee9f4710832c83e7db83ce12f60d